### PR TITLE
Remove top-level init file in order to support add-ons

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build Sphinx Documentation
         run: |
-          sphinx-apidoc -o docs/source/api src/
+          sphinx-apidoc -e -o docs/source/api src/hyped --tocfile hyped
           make -C docs html
 
       - name: Deploy to Github Pages

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,2 +1,2 @@
-sphinx-apidoc -o source/api ../src/
+sphinx-apidoc -f -e -o source/api ../src/hyped --tocfile hyped
 make html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../../src/hyped"))
 
+
 # import all modules
 import hyped
 import hyped.__version__

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,11 +7,11 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../../src"))
-
+sys.path.insert(0, os.path.abspath("../../src/hyped"))
 
 # import all modules
 import hyped
+import hyped.__version__
 import hyped.data.graph
 import hyped.data.pipe
 import hyped.data.processors.base
@@ -48,8 +48,8 @@ import hyped.data.processors.tokenizers.hf
 project = "hyped"
 copyright = "2024, open-hyped"
 author = "open-hyped"
-version = hyped.__version__
-release = hyped.__version__
+version = hyped.__version__.__version__
+release = hyped.__version__.__version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -58,7 +58,6 @@ extensions = ["sphinx.ext.autodoc"]
 
 templates_path = ["_templates"]
 exclude_patterns = []
-
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ docstring-style = "google"
 [tool.isort]
 profile = "black"
 line_length = 79
+skip = ["docs/source/conf.py"]
 
 [tool.ruff]
 line-length = 79

--- a/src/hyped/__init__.py
+++ b/src/hyped/__init__.py
@@ -1,2 +1,0 @@
-"""Hyped."""
-from hyped.__version__ import __version__, __version_tuple__


### PR DESCRIPTION
This pull request reworks the package structure to support namespace sub-packages, i.e. add-ons.

Specifically one can install add-ons such as `hyped.serve` via pip and use them as
```python
import hyped.data  # from hyped core package
import hyped.serve  # from hyped.serve add-on
```